### PR TITLE
Update ch. 0, "Background information", JS sample

### DIFF
--- a/src/0_background_information.md
+++ b/src/0_background_information.md
@@ -522,8 +522,8 @@ function timer(ms) {
 }
 
 timer(200)
-.then(() => return timer(100))
-.then(() => return timer(50))
+.then(() => timer(100))
+.then(() => timer(50))
 .then(() => console.log("I'm the last one"));
 ```
 


### PR DESCRIPTION
In JavaScript, fat arrow functions consisting of one expression (as opposed to a block of code body incased in `{` `}`) don't need and can't have a `return` statement. Sample code being fixed was not valid JS: https://jsfiddle.net/dbzn1tcj/