### PR TITLE
A fix to issue #38

### DIFF
--- a/src/7_finished_example.md
+++ b/src/7_finished_example.md
@@ -206,3 +206,12 @@ impl Drop for Reactor {
     }
 }
 ```
+
+## A little side note
+
+The comments delimiting the Executor, `Future` implementation and Reactor, 
+emphasize on what is part of the langauge (Future and Waker) and what is not (runtime specifics). 
+Therefore, the comments associate the `Waker` with the `Future` implementation,
+despite its strong relation with the Executor.
+
+


### PR DESCRIPTION
This adds a small side note to the finished example, in regards to what's addressed on issue #38 (an explanation to why `Waker` is within `Future` comments)