### PR TITLE
Fix the example in chapter 6 to compile

### DIFF
--- a/src/6_future_example.md
+++ b/src/6_future_example.md
@@ -168,7 +168,7 @@ const VTABLE: RawWakerVTable = unsafe {
     RawWakerVTable::new(
         |s| mywaker_clone(&*(s as *const MyWaker)),   // clone
         |s| mywaker_wake(&*(s as *const MyWaker)),    // wake
-        |s| (*(s as *const MyWaker)).parker.unpark(), // wake by ref (don't decrease refcount)
+        |s| (*(s as *const MyWaker)).thread.unpark(), // wake by ref (don't decrease refcount)
         |s| drop(Arc::from_raw(s as *const MyWaker)), // decrease refcount
     )
 };


### PR DESCRIPTION
Before we introduced the better `Parker` we were using a thread. The example code for executor need to use `thread` instead of `parker`.

Also big thanks to your books. I read all four :) 